### PR TITLE
Fix proton plan spot parsing

### DIFF
--- a/plan.py
+++ b/plan.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 from pathlib import Path
+from typing import Iterable
 
 import bpy
 import pydicom
@@ -31,6 +32,16 @@ def is_photon_plan(ds: pydicom.Dataset) -> bool:
         return False
 
 
+def _as_float_list(values) -> list[float]:
+    if values is None:
+        return []
+    if isinstance(values, (str, bytes)):
+        return []
+    if isinstance(values, Iterable):
+        return [float(value) for value in values]
+    return [float(values)]
+
+
 def load_proton_plan(file_path: Path) -> bool:
     try:
         dataset = pydicom.dcmread(file_path)
@@ -48,7 +59,7 @@ def load_proton_plan(file_path: Path) -> bool:
         return False
 
     for beam_index, beam in enumerate(ion_beams):
-        control_points = beam.IonControlPointSequence
+        control_points = getattr(beam, "IonControlPointSequence", None)
         if not control_points:
             show_message_box(f"Beam {beam_index} has no control points.", "Error", "ERROR")
             continue
@@ -61,8 +72,9 @@ def load_proton_plan(file_path: Path) -> bool:
         spot_weights: list[float] = []
 
         for idx in range(0, num_control_points, 2):
-            positions = getattr(control_points[idx], "ScanSpotPositionMap", None)
-            weights = getattr(control_points[idx], "ScanSpotMetersetWeights", None)
+            control_point = control_points[idx]
+            positions = _as_float_list(getattr(control_point, "ScanSpotPositionMap", None))
+            weights = _as_float_list(getattr(control_point, "ScanSpotMetersetWeights", None))
             if not positions or not weights:
                 show_message_box(
                     f"Beam {beam_index} control point {idx} is missing spot positions or weights.",
@@ -77,27 +89,31 @@ def load_proton_plan(file_path: Path) -> bool:
                     "ERROR",
                 )
                 continue
-            for pos_index in range(0, len(positions), 2):
+
+            spot_count = len(positions) // 2
+            if len(weights) < spot_count:
+                show_message_box(
+                    f"Beam {beam_index} control point {idx} has fewer weights than positions.",
+                    "Error",
+                    "ERROR",
+                )
+                continue
+
+            nominal_energy = float(getattr(control_point, "NominalBeamEnergy", 0.0)) / 1000.0
+            for spot_index in range(spot_count):
+                pos_index = spot_index * 2
                 x_vals.append(positions[pos_index] / 1000.0)
                 y_vals.append(positions[pos_index + 1] / 1000.0)
-                weight_index = int(pos_index / 2)
-                if weight_index >= len(weights):
-                    show_message_box(
-                        f"Beam {beam_index} control point {idx} has fewer weights than positions.",
-                        "Error",
-                        "ERROR",
-                    )
-                    continue
-                energies.append(float(getattr(control_points[idx], "NominalBeamEnergy", 0.0)) / 1000.0)
-                spot_weights.append(weights[weight_index])
-
-        mesh = bpy.data.meshes.new(name=f"proton_spots_{beam_index}")
-        data_fields = ["spot_x", "spot_y", "spot_E", "spot_weight"]
-        add_data_fields(mesh, data_fields)
+                energies.append(nominal_energy)
+                spot_weights.append(weights[spot_index])
 
         count = len(spot_weights)
         if count == 0:
             continue
+
+        mesh = bpy.data.meshes.new(name=f"proton_spots_{beam_index}")
+        data_fields = ["spot_x", "spot_y", "spot_E", "spot_weight"]
+        add_data_fields(mesh, data_fields)
         mesh.vertices.add(count)
 
         for row in range(count):


### PR DESCRIPTION
### Motivation
- Robustly import RT Ion (proton) plans by preventing misaligned spot attribute arrays and index errors when control points are malformed or values are provided as scalars rather than sequences.
- Avoid creating empty Blender mesh datablocks for beams with no valid spots and fail gracefully when expected sequences are missing.

### Description
- Added `_as_float_list()` to normalize `ScanSpotPositionMap` and `ScanSpotMetersetWeights` into a list of floats so scalar or byte/string-like DICOM values are handled consistently in `plan.py`.
- Use `getattr(..., "IonControlPointSequence", None)` to avoid attribute errors when beams are malformed and validate the presence of control points before processing them.
- Validate each control point (including matching spot counts and weights) before appending spot records and compute `NominalBeamEnergy` once per control point so `x_vals`, `y_vals`, `energies`, and `spot_weights` remain aligned.
- Move Blender mesh creation until after the validated `spot_weights` count is known to prevent creating empty mesh datablocks for beams without valid spots (changes in `plan.py`).

### Testing
- Ran `python -m py_compile __init__.py blender_utils.py constants.py ct.py dicom_util.py dose.py node_groups.py plan.py proton.py structure.py ui_utils.py volume_utils.py` and it completed without syntax errors.
- Ran `python -m compileall -q .` and it completed with no failures.
- Ran `git diff --check` to validate whitespace/patch issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be43457c0c8321b2bd90fe81d3fe51)