### PR TITLE
Add DICOM image rescaling to CT volume loading pipeline

### DIFF
--- a/ct.py
+++ b/ct.py
@@ -12,6 +12,7 @@ from .dicom_util import (
     extract_dicom_data,
     filter_by_series_uid,
     load_dicom_images,
+    rescale_dicom_image,
     sort_by_instance_number,
 )
 from .node_groups import apply_dicom_shader
@@ -52,6 +53,8 @@ def load_ct_series(file_path: Path) -> bool:
     except Exception as exc:
         show_message_box(str(exc), "Error", "ERROR")
         return False
+
+    ct_volume = rescale_dicom_image(ct_volume)
 
     slice_spacing = slice_spacing or 1.0
     spacing_values = (float(slice_spacing), float(spacing[0]), float(spacing[1]))


### PR DESCRIPTION
## Summary
This change integrates DICOM image rescaling into the CT series loading workflow by applying the `rescale_dicom_image` function to the loaded CT volume.

## Key Changes
- Import the `rescale_dicom_image` function from the dicom utilities module
- Apply `rescale_dicom_image` to the `ct_volume` immediately after loading and before further processing
- The rescaling is performed before spacing calculations and shader application

## Implementation Details
The rescaling operation is inserted at a strategic point in the `load_ct_series` function—after the DICOM images have been loaded and extracted into a volume, but before the volume is used for spacing calculations and visualization. This ensures that all downstream operations work with properly rescaled image data.

https://claude.ai/code/session_01WUp7iy8fs6y4Rbe7YWn85t