### PR TITLE
Fail proton import when no spots found and harden VDB temp-dir fallback

### DIFF
--- a/plan.py
+++ b/plan.py
@@ -58,6 +58,8 @@ def load_proton_plan(file_path: Path) -> bool:
         show_message_box("RT Ion plan is missing IonBeamSequence.", "Error", "ERROR")
         return False
 
+    imported_beam_count = 0
+
     for beam_index, beam in enumerate(ion_beams):
         control_points = getattr(beam, "IonControlPointSequence", None)
         if not control_points:
@@ -109,6 +111,11 @@ def load_proton_plan(file_path: Path) -> bool:
 
         count = len(spot_weights)
         if count == 0:
+            show_message_box(
+                f"Beam {beam_index} did not contain any valid scan spot data.",
+                "Error",
+                "ERROR",
+            )
             continue
 
         mesh = bpy.data.meshes.new(name=f"proton_spots_{beam_index}")
@@ -134,5 +141,14 @@ def load_proton_plan(file_path: Path) -> bool:
             obj.rotation_euler[1] = gantry_angle * math.pi / 180.0
             obj.location = (iso_center[0], iso_center[1], iso_center[2])
             apply_proton_spots_geo_nodes(node_tree_name="Proton_Spots")
+            imported_beam_count += 1
+
+    if imported_beam_count == 0:
+        show_message_box(
+            "No proton beam spot data could be imported from this RT Ion plan.",
+            "Error",
+            "ERROR",
+        )
+        return False
 
     return True

--- a/volume_utils.py
+++ b/volume_utils.py
@@ -54,7 +54,12 @@ def resolve_temp_path(target_name: str, base_dir: Optional[Path] = None) -> Path
             "ERROR",
         )
         base_dir = _default_temp_base_dir()
-        base_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            base_dir.mkdir(parents=True, exist_ok=True)
+        except Exception as fallback_exc:
+            raise RuntimeError(
+                f"Failed to create fallback VDB directory '{base_dir}': {fallback_exc}"
+            ) from fallback_exc
 
     return base_dir / target_name
 


### PR DESCRIPTION
### Motivation
- Prevent false-positive success from RT Ion (proton) plan imports that produce no visible data and provide clearer per-beam feedback.
- Make VDB temporary directory resolution more robust by surfacing fallback directory creation failures immediately.

### Description
- Add an `imported_beam_count` guard and per-beam error message when a beam contains no valid scan spot data, and return `False` from `load_proton_plan` if no beams were imported (changes in `plan.py`).
- Increment `imported_beam_count` when a proton beam mesh/object is successfully created and show a final error message when zero beams were imported (changes in `plan.py`).
- Harden `resolve_temp_path` fallback handling by catching exceptions from the fallback `mkdir` and raising a clear `RuntimeError` if creating the fallback VDB directory fails (changes in `volume_utils.py`).

### Testing
- Compiled the Python modules with `python -m py_compile __init__.py blender_utils.py constants.py ct.py dicom_util.py dose.py node_groups.py plan.py proton.py structure.py ui_utils.py volume_utils.py` and the compilation succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1691f72048321b74817d64a0d75da)