### PR TITLE
Fix RT dose scaling and optimize bundled wheel extraction

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -27,8 +27,12 @@ def _add_bundled_wheels_to_sys_path() -> None:
     lib_dir.mkdir(exist_ok=True)
 
     for wheel in sorted(wheels_dir.glob("*.whl")):
+        marker = lib_dir / f".{wheel.stem}.extracted"
+        if marker.exists():
+            continue
         with zipfile.ZipFile(wheel) as zf:
             zf.extractall(lib_dir)
+        marker.touch()
 
     lib_path = str(lib_dir)
     if lib_path not in sys.path:

--- a/dose.py
+++ b/dose.py
@@ -68,7 +68,12 @@ def load_dose(file_path: Path) -> bool:
 
     dose_resolution = [slice_spacing, row_spacing, col_spacing]
 
-    dose_matrix = np.asarray(pixel_data)
+    dose_matrix = np.asarray(pixel_data, dtype=float)
+    dose_grid_scaling = float(getattr(dataset, "DoseGridScaling", 1.0) or 1.0)
+    if dose_grid_scaling <= 0:
+        show_message_box("DoseGridScaling is invalid; expected a positive value.", "Error", "ERROR")
+        return False
+    dose_matrix *= dose_grid_scaling
     if dose_matrix.ndim == 2:
         dose_matrix = dose_matrix[np.newaxis, ...]
 


### PR DESCRIPTION
### Motivation
- Ensure RT Dose imports represent physical dose by applying `DoseGridScaling` to stored pixel values before exporting volumes.
- Reduce add-on startup overhead and avoid repeatedly extracting bundled wheel archives on every load.

### Description
- Multiply the parsed dose pixel array by `DoseGridScaling` and cast the pixel array to `float`, and fail with a clear error if `DoseGridScaling` is missing or non-positive (changes in `dose.py`).
- Add a per-wheel marker file in the add-on `lib/` directory to skip re-extracting a `.whl` if it was already extracted (changes in `__init__.py`).
- Add minimal validation for the scaling value and preserve prior behavior when scaling is not present by defaulting to `1.0`.

### Testing
- Ran `python -m compileall -q .` which completed successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8ec8d02c8321954391d5dd751316)