### PR TITLE
Fix co-registration, structure import robustness, and import performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,14 @@ Once installed, open the 3D viewport and select the Medical category from the si
 
 If Blender cannot write temporary VDB files in its default temp location, open the MedBlend add-on preferences and set a `VDB Temp Directory` that your user account can write to.
 
+> **Note on saving .blend files:** Blender volume objects read their voxel data from the VDB file on disk. By default MedBlend writes VDB files to Blender's session temporary directory, which is deleted when Blender exits — so a saved .blend file will lose its volume data on the next reload. If you plan to save your scene, set a persistent `VDB Temp Directory` in the MedBlend preferences first. Files in that directory are never overwritten or cleaned up automatically (each import writes a new uniquely-named file), so clear it out occasionally.
+
 <img width="393" height="349" alt="Screenshot 2026-03-08 at 9 17 49 pm" src="https://github.com/user-attachments/assets/d000dc5a-3752-46c7-a758-292e3ed7b100" />
 
 
 MedBlend currently has 4 main functions: Load DICOM images, Load DICOM Dose, Load DICOM structures and Load Proton Plan. Each of these functions imports a specific DICOM medical file. 
 
--Load DICOM Images, will allow you to load a DICOM image sequence from a specified folder. When you press the load images button, a file dialog will appear. Select a single DICOM image from this folder. MedBlend will search through the same directory and load all DICOM images with the same study ID into Blender automatically. These image slices will be imported and converted to a volume object which can be rendered in Blender. 
+-Load DICOM Images, will allow you to load a DICOM image sequence from a specified folder. When you press the load images button, a file dialog will appear. Select a single DICOM image from this folder. MedBlend will search through the same directory and load all DICOM images belonging to the same series (matching SeriesInstanceUID) into Blender automatically. These image slices will be imported and converted to a volume object which can be rendered in Blender. 
 
 -Load DICOM Dose will allow you to import radiation therapy DICOM Dose Files from a treatment planning system and display the dose distribution as a volume in Blender. 
 
@@ -152,7 +154,8 @@ A test proton therapy plan on a phantom. The CT images, dose distribution and pr
 
 ## Known Issues
 - Not tested on MRI, SPECT, PET or other imaging modalities.
-- CT, Dose and Structure locations are not perfectly co-registered yet (user may need to manually align them at the moment).
+- Imported CT, dose, structure, and proton spot objects are now all placed in the DICOM patient coordinate system (millimetres mapped to metres), so they co-register automatically regardless of import order. Note that the CT volume is therefore no longer centred at the world origin.
+- Proton beam orientation (gantry and couch rotation) assumes a head-first supine (HFS) patient; other patient orientations have not been verified and a warning is shown when the plan reports a different patient position.
 - If bundled dependencies were missing from the installed package, MedBlend will fail to load. Reinstall using the official release zip and ensure the `wheels/` directory is included.
 
 Please report any bugs as an issue on this repository

--- a/__init__.py
+++ b/__init__.py
@@ -96,7 +96,11 @@ class MEDBLEND_Preferences(bpy.types.AddonPreferences):
 
     vdb_temp_dir: bpy.props.StringProperty(
         name="VDB Temp Directory",
-        description="Directory to store temporary VDB files",
+        description=(
+            "Directory to store generated VDB files. If empty, Blender's session "
+            "temporary directory is used, which is deleted when Blender exits - "
+            "volumes in saved .blend files will then lose their data on reload"
+        ),
         subtype="DIR_PATH",
         default="",
     )

--- a/constants.py
+++ b/constants.py
@@ -1,4 +1,0 @@
-from pathlib import Path
-
-ADDON_DIR = Path(__file__).resolve().parent
-# Folder for the addon on the local machine.

--- a/ct.py
+++ b/ct.py
@@ -10,14 +10,13 @@ import pydicom
 from .dicom_util import (
     check_dicom_image_type,
     extract_dicom_data,
-    filter_by_series_uid,
-    load_dicom_images,
+    load_dicom_series,
     rescale_dicom_image,
     sort_slices_spatially,
 )
 from .node_groups import apply_dicom_shader
 from .ui_utils import show_message_box
-from .volume_utils import write_vdb_volume
+from .volume_utils import set_object_patient_transform, write_vdb_volume
 
 
 def load_ct_series(file_path: Path) -> bool:
@@ -36,19 +35,17 @@ def load_ct_series(file_path: Path) -> bool:
         show_message_box("Missing SeriesInstanceUID on selected DICOM.", "Error", "ERROR")
         return False
 
-    images = load_dicom_images(file_path.parent)
-    filtered_images = filter_by_series_uid(images, series_uid)
-    sorted_images = sort_slices_spatially(filtered_images)
+    images = load_dicom_series(file_path.parent, series_uid)
+    sorted_images = sort_slices_spatially(images)
 
     try:
         (
             ct_volume,
             spacing,
-            _slice_position,
+            slice_positions_raw,
             slice_spacing,
-            _image_origin,
-            _image_orientation,
-            _image_columns,
+            image_origin,
+            image_orientation,
         ) = extract_dicom_data(sorted_images)
     except Exception as exc:
         show_message_box(str(exc), "Error", "ERROR")
@@ -65,7 +62,7 @@ def load_ct_series(file_path: Path) -> bool:
     _output_path, ct_object = result
 
     try:
-        orientation = np.asarray(_image_orientation, dtype=float)
+        orientation = np.asarray(image_orientation, dtype=float)
         row_dir = orientation[:3]
         col_dir = orientation[3:]
         normal_dir = np.cross(row_dir, col_dir)
@@ -77,11 +74,11 @@ def load_ct_series(file_path: Path) -> bool:
 
         # Array axis 0 is flipped in extract_dicom_data, so the imported array origin
         # corresponds to the final source slice position.
-        slice_positions = np.asarray(_slice_position, dtype=float)
+        slice_positions = np.asarray(slice_positions_raw, dtype=float)
         if slice_positions.ndim == 2 and slice_positions.shape[1] == 3 and len(slice_positions) > 0:
             array_origin = slice_positions[-1]
         else:
-            array_origin = np.asarray(_image_origin, dtype=float)
+            array_origin = np.asarray(image_origin, dtype=float)
 
         row_spacing = float(spacing[0])
         col_spacing = float(spacing[1])
@@ -100,6 +97,20 @@ def load_ct_series(file_path: Path) -> bool:
         ct_object["medblend_ct_origin_mm"] = [float(v) for v in array_origin]
         ct_object["medblend_ct_basis_mm"] = [float(v) for v in basis.reshape(-1)]
         ct_object["medblend_ct_spacing_mm"] = [float(v) for v in spacing_values]
+
+        # Place the CT in DICOM patient coordinates (mm -> m) so dose,
+        # structures, and proton plans land in the same frame regardless of
+        # import order.
+        row_norm = float(np.linalg.norm(row_dir))
+        col_norm = float(np.linalg.norm(col_dir))
+        if row_norm > 0 and col_norm > 0 and normal_norm > 0:
+            set_object_patient_transform(
+                ct_object,
+                array_origin,
+                -normal_dir,
+                col_dir / col_norm,
+                row_dir / row_norm,
+            )
     except Exception:
         # Metadata is best-effort and should not block import.
         pass

--- a/dicom_util.py
+++ b/dicom_util.py
@@ -36,22 +36,34 @@ def check_dicom_image_type(ds: pydicom.Dataset) -> bool:
         return False
 
 
-def load_dicom_images(folder: Path) -> List[pydicom.Dataset]:
-    """Load all CT/MR DICOM files within ``folder``."""
+def load_dicom_series(folder: Path, series_uid: str) -> List[pydicom.Dataset]:
+    """Load the CT/MR files in ``folder`` that belong to ``series_uid``.
 
-    images: List[pydicom.Dataset] = []
-    for file_path in folder.iterdir():
+    Scans headers only (``stop_before_pixels``) first, so pixel data is read
+    and decoded just for the slices of the requested series rather than for
+    every file in the directory.
+    """
+
+    matching_paths: List[Path] = []
+    for file_path in sorted(folder.iterdir()):
         if not file_path.is_file():
             continue
-
         try:
-            image = pydicom.dcmread(file_path)
+            header = pydicom.dcmread(file_path, stop_before_pixels=True)
         except Exception:
             continue
+        if not check_dicom_image_type(header):
+            continue
+        if getattr(header, "SeriesInstanceUID", None) != series_uid:
+            continue
+        matching_paths.append(file_path)
 
-        if image and check_dicom_image_type(image):
-            images.append(image)
-
+    images: List[pydicom.Dataset] = []
+    for file_path in matching_paths:
+        try:
+            images.append(pydicom.dcmread(file_path))
+        except Exception:
+            continue
     return images
 
 
@@ -151,9 +163,16 @@ def _compute_slice_spacing(
     return spacing if spacing > 0 else 1.0
 
 
+def _float_or(value, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def extract_dicom_data(
     images: Sequence[pydicom.Dataset],
-) -> Tuple[np.ndarray, Sequence[float], Sequence[float], float, Sequence[float], Sequence[float], int]:
+) -> Tuple[np.ndarray, Sequence[float], Sequence[float], float, Sequence[float], Sequence[float]]:
     """Extract voxel data and metadata from the provided DICOM slices."""
 
     if not images:
@@ -162,7 +181,14 @@ def extract_dicom_data(
     dicom_3d_array = []
     slice_positions = []
     for dataset in images:
-        dicom_3d_array.append(dataset.pixel_array)
+        pixels = np.asarray(dataset.pixel_array, dtype=np.float32)
+        # Apply the modality LUT per slice: RescaleSlope/Intercept may differ
+        # between slices, in which case raw stored values are not comparable.
+        slope = _float_or(getattr(dataset, "RescaleSlope", 1.0), 1.0)
+        intercept = _float_or(getattr(dataset, "RescaleIntercept", 0.0), 0.0)
+        if slope != 1.0 or intercept != 0.0:
+            pixels = pixels * slope + intercept
+        dicom_3d_array.append(pixels)
         slice_positions.append(getattr(dataset, "ImagePositionPatient", (0.0, 0.0, 0.0)))
 
     array = np.asarray(dicom_3d_array)
@@ -172,7 +198,6 @@ def extract_dicom_data(
     spacing = getattr(first, "PixelSpacing", (1.0, 1.0))
     image_origin = getattr(first, "ImagePositionPatient", (0.0, 0.0, 0.0))
     image_orientation = getattr(first, "ImageOrientationPatient", (0.0,) * 6)
-    image_columns = getattr(first, "Columns", 0)
     slice_spacing = _compute_slice_spacing(
         slice_positions,
         image_orientation,
@@ -186,11 +211,4 @@ def extract_dicom_data(
         slice_spacing,
         image_origin,
         image_orientation,
-        image_columns,
     )
-
-
-def filter_by_series_uid(images: Iterable[pydicom.Dataset], series_uid: str) -> List[pydicom.Dataset]:
-    """Return the images that match the requested ``SeriesInstanceUID``."""
-
-    return [image for image in images if getattr(image, "SeriesInstanceUID", None) == series_uid]

--- a/dose.py
+++ b/dose.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import numpy as np
 import pydicom
 
 from .dicom_util import is_dose_file
@@ -26,12 +27,6 @@ def load_dose(file_path: Path) -> bool:
 
     if not is_dose_file(dataset):
         show_message_box("Selected file is not an RT Dose file.", "Error", "ERROR")
-        return False
-
-    try:
-        import numpy as np
-    except Exception as exc:
-        show_message_box(f"numpy is required to load dose data: {exc}", "Missing Dependency", "ERROR")
         return False
 
     try:

--- a/plan.py
+++ b/plan.py
@@ -1,4 +1,4 @@
-"""Plan import helpers for proton and photon data."""
+"""Proton (RT Ion) plan import helpers."""
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ from typing import Iterable
 
 import bpy
 import pydicom
+from mathutils import Matrix
 
 from .blender_utils import add_data_fields, create_object
 from .node_groups import apply_proton_spots_geo_nodes
@@ -23,15 +24,6 @@ def is_proton_plan(ds: pydicom.Dataset) -> bool:
         return False
 
 
-def is_photon_plan(ds: pydicom.Dataset) -> bool:
-    """Return ``True`` when the dataset represents an RT Photon plan."""
-
-    try:
-        return str(ds.Modality).upper() == "RTPLAN"
-    except Exception:
-        return False
-
-
 def _as_float_list(values) -> list[float]:
     if values is None:
         return []
@@ -40,6 +32,36 @@ def _as_float_list(values) -> list[float]:
     if isinstance(values, Iterable):
         return [float(value) for value in values]
     return [float(values)]
+
+
+def _patient_position(dataset: pydicom.Dataset) -> str:
+    try:
+        setups = getattr(dataset, "PatientSetupSequence", [])
+        if setups:
+            return str(getattr(setups[0], "PatientPosition", "")).upper()
+    except Exception:
+        pass
+    return ""
+
+
+def _beam_world_matrix(control_point: pydicom.Dataset) -> Matrix:
+    """Build the beam object's world matrix in DICOM patient coordinates.
+
+    Assumes a head-first supine (HFS) patient: the IEC gantry rotation axis is
+    the patient superior-inferior axis (DICOM +Z), and the couch
+    (PatientSupportAngle) rotates the beam about the room-vertical axis, which
+    maps to the patient +Y axis in this convention.
+    """
+
+    gantry_angle = float(getattr(control_point, "GantryAngle", 0.0) or 0.0)
+    couch_angle = float(getattr(control_point, "PatientSupportAngle", 0.0) or 0.0)
+    iso_center_raw = getattr(control_point, "IsocenterPosition", (0.0, 0.0, 0.0))
+    iso_center = tuple(float(val) / 1000.0 for val in iso_center_raw)
+
+    rotation = Matrix.Rotation(math.radians(couch_angle), 4, "Y") @ Matrix.Rotation(
+        math.radians(gantry_angle), 4, "Z"
+    )
+    return Matrix.Translation(iso_center) @ rotation
 
 
 def load_proton_plan(file_path: Path) -> bool:
@@ -58,12 +80,19 @@ def load_proton_plan(file_path: Path) -> bool:
         show_message_box("RT Ion plan is missing IonBeamSequence.", "Error", "ERROR")
         return False
 
+    warnings: list[str] = []
+    patient_position = _patient_position(dataset)
+    if patient_position and patient_position != "HFS":
+        warnings.append(
+            f"Patient position is {patient_position}; beam orientation assumes HFS."
+        )
+
     imported_beam_count = 0
 
     for beam_index, beam in enumerate(ion_beams):
         control_points = getattr(beam, "IonControlPointSequence", None)
         if not control_points:
-            show_message_box(f"Beam {beam_index} has no control points.", "Error", "ERROR")
+            warnings.append(f"Beam {beam_index} has no control points.")
             continue
 
         num_control_points = len(control_points)
@@ -73,35 +102,31 @@ def load_proton_plan(file_path: Path) -> bool:
         energies: list[float] = []
         spot_weights: list[float] = []
 
+        # Spot data lives on the first control point of each pair; the second
+        # of a pair only carries cumulative meterset bookkeeping.
         for idx in range(0, num_control_points, 2):
             control_point = control_points[idx]
             positions = _as_float_list(getattr(control_point, "ScanSpotPositionMap", None))
             weights = _as_float_list(getattr(control_point, "ScanSpotMetersetWeights", None))
             if not positions or not weights:
-                show_message_box(
-                    f"Beam {beam_index} control point {idx} is missing spot positions or weights.",
-                    "Error",
-                    "ERROR",
+                warnings.append(
+                    f"Beam {beam_index} control point {idx} is missing spot positions or weights."
                 )
                 continue
             if len(positions) % 2 != 0:
-                show_message_box(
-                    f"Beam {beam_index} control point {idx} has an odd number of spot positions.",
-                    "Error",
-                    "ERROR",
+                warnings.append(
+                    f"Beam {beam_index} control point {idx} has an odd number of spot positions."
                 )
                 continue
 
             spot_count = len(positions) // 2
             if len(weights) < spot_count:
-                show_message_box(
-                    f"Beam {beam_index} control point {idx} has fewer weights than positions.",
-                    "Error",
-                    "ERROR",
+                warnings.append(
+                    f"Beam {beam_index} control point {idx} has fewer weights than positions."
                 )
                 continue
 
-            nominal_energy = float(getattr(control_point, "NominalBeamEnergy", 0.0)) / 1000.0
+            nominal_energy = float(getattr(control_point, "NominalBeamEnergy", 0.0) or 0.0) / 1000.0
             for spot_index in range(spot_count):
                 pos_index = spot_index * 2
                 x_vals.append(positions[pos_index] / 1000.0)
@@ -111,11 +136,7 @@ def load_proton_plan(file_path: Path) -> bool:
 
         count = len(spot_weights)
         if count == 0:
-            show_message_box(
-                f"Beam {beam_index} did not contain any valid scan spot data.",
-                "Error",
-                "ERROR",
-            )
+            warnings.append(f"Beam {beam_index} did not contain any valid scan spot data.")
             continue
 
         mesh = bpy.data.meshes.new(name=f"proton_spots_{beam_index}")
@@ -136,11 +157,7 @@ def load_proton_plan(file_path: Path) -> bool:
 
         if mesh.vertices:
             obj = create_object(mesh, mesh.name)
-            gantry_angle = float(getattr(control_points[0], "GantryAngle", 0.0))
-            iso_center_raw = getattr(control_points[0], "IsocenterPosition", (0.0, 0.0, 0.0))
-            iso_center = tuple(val / 1000.0 for val in iso_center_raw)
-            obj.rotation_euler[1] = gantry_angle * math.pi / 180.0
-            obj.location = (iso_center[0], iso_center[1], iso_center[2])
+            obj.matrix_world = _beam_world_matrix(control_points[0])
             apply_proton_spots_geo_nodes(node_tree_name="Proton_Spots")
             imported_beam_count += 1
 
@@ -151,5 +168,15 @@ def load_proton_plan(file_path: Path) -> bool:
             "ERROR",
         )
         return False
+
+    if warnings:
+        preview = "; ".join(warnings[:3])
+        if len(warnings) > 3:
+            preview += f"; and {len(warnings) - 3} more"
+        show_message_box(
+            f"Imported {imported_beam_count} beam(s) with {len(warnings)} warning(s): {preview}",
+            "Proton Import Warnings",
+            "ERROR",
+        )
 
     return True

--- a/proton.py
+++ b/proton.py
@@ -1,8 +1,0 @@
-"""Backward-compatible proton helpers (deprecated)."""
-
-from __future__ import annotations
-
-from .plan import is_proton_plan
-
-__all__ = ["is_proton_plan"]
-

--- a/structure.py
+++ b/structure.py
@@ -322,7 +322,22 @@ def _contour_points_to_ijk(points_xyz: np.ndarray, origin: np.ndarray, inv_basis
     return (inv_basis @ diffs.T).T
 
 
-def _rtstruct_to_masks(dicom_structure: pydicom.Dataset, geometry) -> tuple[list[np.ndarray], list[str]]:
+def _roi_display_color(roi_contour: pydicom.Dataset) -> tuple[float, float, float, float] | None:
+    display_color = getattr(roi_contour, "ROIDisplayColor", None)
+    if display_color is None:
+        return None
+    try:
+        values = [float(component) for component in display_color]
+    except (TypeError, ValueError):
+        return None
+    if len(values) < 3:
+        return None
+    return (values[0] / 255.0, values[1] / 255.0, values[2] / 255.0, 1.0)
+
+
+def _rtstruct_to_masks(
+    dicom_structure: pydicom.Dataset, geometry
+) -> tuple[list[np.ndarray], list[str], list[tuple[float, float, float, float] | None]]:
     roi_names = {}
     for roi in getattr(dicom_structure, "StructureSetROISequence", []):
         roi_number = int(getattr(roi, "ROINumber", -1))
@@ -337,6 +352,7 @@ def _rtstruct_to_masks(dicom_structure: pydicom.Dataset, geometry) -> tuple[list
 
     struct_masks: list[np.ndarray] = []
     struct_names: list[str] = []
+    struct_colors: list[tuple[float, float, float, float] | None] = []
 
     for roi_contour in getattr(dicom_structure, "ROIContourSequence", []):
         roi_number = int(getattr(roi_contour, "ReferencedROINumber", -1))
@@ -344,8 +360,13 @@ def _rtstruct_to_masks(dicom_structure: pydicom.Dataset, geometry) -> tuple[list
         volume_mask = np.zeros((num_slices, rows, cols), dtype=bool)
 
         for contour in getattr(roi_contour, "ContourSequence", []):
+            # Only closed planar contours describe filled regions; open
+            # contours and single points must not be rasterized as polygons.
+            geometric_type = str(getattr(contour, "ContourGeometricType", "CLOSED_PLANAR")).upper()
+            if geometric_type not in {"CLOSED_PLANAR", "CLOSEDPLANAR_XOR"}:
+                continue
             contour_data = getattr(contour, "ContourData", None)
-            if not contour_data or len(contour_data) < 9:
+            if not contour_data or len(contour_data) < 9 or len(contour_data) % 3 != 0:
                 continue
 
             points_xyz = np.asarray(contour_data, dtype=float).reshape((-1, 3))
@@ -364,8 +385,9 @@ def _rtstruct_to_masks(dicom_structure: pydicom.Dataset, geometry) -> tuple[list
         if np.any(volume_mask):
             struct_masks.append(volume_mask.astype(float))
             struct_names.append(roi_name)
+            struct_colors.append(_roi_display_color(roi_contour))
 
-    return struct_masks, struct_names
+    return struct_masks, struct_names, struct_colors
 
 
 def load_structures(file_path: Path) -> bool:
@@ -388,7 +410,7 @@ def load_structures(file_path: Path) -> bool:
             geometry = _build_geometry(image_slices)
         else:
             geometry = _build_geometry_from_contours(dicom_structure)
-        struct_masks, struct_names = _rtstruct_to_masks(dicom_structure, geometry)
+        struct_masks, struct_names, struct_colors = _rtstruct_to_masks(dicom_structure, geometry)
     except Exception as exc:
         show_message_box(
             f"Unable to convert RT Structure contours: {exc}",
@@ -404,11 +426,13 @@ def load_structures(file_path: Path) -> bool:
     spacing = geometry["spacing"]
     frame_uid = _get_structure_frame_uid(dicom_structure)
     ct_anchor = find_ct_anchor(frame_uid)
-    for mask, name in zip(struct_masks, struct_names):
-        result = write_vdb_volume(mask.astype(float), spacing, f"{name}.vdb")
+    for mask, name, color in zip(struct_masks, struct_names, struct_colors):
+        result = write_vdb_volume(mask, spacing, f"{name}.vdb")
         if not result:
             return False
         _output_path, imported_obj = result
+        if color:
+            imported_obj.color = color
         aligned = False
         if ct_anchor:
             aligned = align_object_to_ct_frame(

--- a/volume_utils.py
+++ b/volume_utils.py
@@ -66,12 +66,8 @@ def _unique_path(base_dir: Path, target_name: str) -> Path:
         counter += 1
 
 
-def resolve_temp_path(target_name: str, base_dir: Optional[Path] = None) -> Path:
-    preferred_dir = _get_vdb_temp_dir()
-    if preferred_dir:
-        base_dir = preferred_dir
-    else:
-        base_dir = Path(base_dir) if base_dir else _default_temp_base_dir()
+def resolve_temp_path(target_name: str) -> Path:
+    base_dir = _get_vdb_temp_dir() or _default_temp_base_dir()
 
     try:
         base_dir.mkdir(parents=True, exist_ok=True)
@@ -170,7 +166,10 @@ def align_object_to_ct_frame(
             )
         )
         matrix.translation = tuple(float(value) for value in translation)
-        obj.matrix_world = matrix
+        # ``matrix`` maps the new object into the CT object's local frame, so
+        # compose with the CT's current world matrix. This keeps alignment
+        # correct even when the user has moved/rotated/scaled the CT object.
+        obj.matrix_world = ct_obj.matrix_world @ matrix
     except Exception:
         return False
 
@@ -227,7 +226,6 @@ def write_vdb_volume(
     array,
     spacing: Sequence[float],
     target_name: str,
-    dicom_dir: Optional[Path] = None,
 ) -> Optional[Tuple[Path, bpy.types.Object]]:
     if len(spacing) != 3:
         show_message_box(
@@ -252,7 +250,9 @@ def write_vdb_volume(
 
     try:
         grid = openvdb.FloatGrid()
-        grid.copyFromArray(array.astype(float))
+        # FloatGrid stores single precision; converting up front halves peak
+        # memory and avoids dtype-strict copyFromArray builds rejecting float64.
+        grid.copyFromArray(np.ascontiguousarray(array, dtype=np.float32))
         grid.transform = openvdb.createLinearTransform(
             [
                 [spacing[0] / 1000.0, 0, 0, 0],
@@ -264,7 +264,7 @@ def write_vdb_volume(
         grid.gridClass = openvdb.GridClass.FOG_VOLUME
         grid.name = "density"
 
-        output_path = resolve_temp_path(target_name, dicom_dir)
+        output_path = resolve_temp_path(target_name)
         openvdb.write(str(output_path), grid)
 
         try:


### PR DESCRIPTION
- Place imported CT volumes in DICOM patient coordinates so CT, dose,
  structures, and proton spots co-register regardless of import order
- Compose the CT object's current world matrix into align_object_to_ct_frame
  so dose/structures follow a CT the user has moved
- Skip malformed contours (length not divisible by 3) and non-closed-planar
  contours instead of aborting the whole RT structure import
- Set per-ROI viewport color from ROIDisplayColor
- Scan DICOM headers only when collecting a series, decoding pixel data just
  for matching slices
- Apply RescaleSlope/RescaleIntercept per slice before stacking
- Apply IEC gantry (about Z) and couch (about Y) rotations for proton beams,
  assuming HFS, and warn on other patient positions
- Aggregate proton import warnings into a single popup
- Write OpenVDB grids as float32 to halve peak memory
- Remove dead code (constants.py, proton.py, is_photon_plan, unused params),
  hoist dose.py numpy import, document VDB temp-dir persistence caveat

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VutNYS9WgZ26eYHtZ7aShU